### PR TITLE
feat: set up rule project

### DIFF
--- a/.cursor/rules/commit-messages-english.mdc
+++ b/.cursor/rules/commit-messages-english.mdc
@@ -1,0 +1,31 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Commit Message Language Rule
+
+## English-Only Commit Messages
+
+All commit messages must be written in **English only**. This ensures consistency and readability for all team members.
+
+### Guidelines:
+- Use clear, concise English for commit messages
+- Follow conventional commit format when applicable (e.g., `feat:`, `fix:`, `docs:`, etc.)
+- Use present tense (e.g., "Add feature" not "Added feature")
+- Keep the first line under 50 characters when possible
+- Use imperative mood (e.g., "Fix bug" not "Fixes bug")
+
+### Examples:
+✅ **Good (English):**
+- `feat: add user authentication system`
+- `fix: resolve login form validation issue`
+- `docs: update API documentation`
+
+❌ **Avoid (Non-English):**
+- `feat: thêm hệ thống xác thực người dùng`
+- `fix: sửa lỗi validation form đăng nhập`
+
+### Note:
+This rule applies to all commits regardless of the developer's native language. English ensures better collaboration and understanding across the development team.
+

--- a/app/components/register/register-form.tsx
+++ b/app/components/register/register-form.tsx
@@ -65,7 +65,7 @@ export default function RegisterForm() {
         </CardDescription>
       </CardHeader>
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8" noValidate>
           <CardContent className="space-y-4">
             <FormField
               control={form.control}
@@ -87,7 +87,7 @@ export default function RegisterForm() {
                 <FormItem>
                   <FormLabel>Email</FormLabel>
                   <FormControl>
-                    <Input placeholder="Email" {...field} />
+                    <Input type="email" placeholder="Email" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
This pull request introduces a new rule for commit messages and makes improvements to the `RegisterForm` component to enhance form validation and accessibility. Below are the most important changes:

### Commit Message Rules

* Added a new rule file `.cursor/rules/commit-messages-english.mdc` specifying that all commit messages must be written in English. The rule includes guidelines for clarity, consistency, and examples of good and bad practices.

### Form Validation Improvements

* Updated the `RegisterForm` component in `app/components/register/register-form.tsx` to include the `noValidate` attribute in the `<form>` element, disabling native HTML validation to allow custom validation handling.
* Changed the `Input` element for the email field to explicitly set the `type` attribute to `email`, improving semantic correctness and enabling browser-level email validation.