### PR TITLE
feat: set up handle error global

### DIFF
--- a/app/components/app/query-provider.tsx
+++ b/app/components/app/query-provider.tsx
@@ -1,7 +1,19 @@
 'use client'
 
-import { QueryClient, QueryClientProvider, HydrationBoundary } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, HydrationBoundary, QueryCache, MutationCache } from '@tanstack/react-query'
 import { useState } from 'react'
+import { toast } from 'sonner'
+
+declare module '@tanstack/react-query'{
+    interface Register{
+        mutationMeta:{
+            doNotShowToast?: boolean
+        }
+        queryMeta:{
+            doNotShowToast?: boolean
+        }
+    }
+} 
 
 export function QueryProvider({ 
   children,
@@ -21,6 +33,21 @@ export function QueryProvider({
         refetchOnReconnect: false,
       },
     },
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        if(!query.meta?.doNotShowToast){
+          toast.error(error.message)
+        }
+      },
+    }),
+    mutationCache: new MutationCache({
+      onError: (error, variables, context, mutation) => {
+        if(!mutation.meta?.doNotShowToast){
+          console.log(error)
+          toast.error(error.message)
+        }
+      },
+    }),
   }))
 
   return (

--- a/app/components/register/register-form.tsx
+++ b/app/components/register/register-form.tsx
@@ -51,9 +51,6 @@ export default function RegisterForm() {
       onSuccess: () => {
         toast.success('Đăng ký thành công')
       },
-      onError: (error) => {
-        toast.error(error.message)
-      },
     })
   }
   return (


### PR DESCRIPTION
This pull request enhances error handling in the `QueryProvider` component by integrating `QueryCache` and `MutationCache` with custom error handling logic. Additionally, it removes redundant error handling in the `RegisterForm` component to centralize error management.

### Enhancements to error handling in `QueryProvider`:

* [`app/components/app/query-provider.tsx`](diffhunk://#diff-8895ce3212eab379a183f1cd98fe1858c5b413b64b85b765ef29d8ba3d071037R36-R50): Added `QueryCache` and `MutationCache` to handle errors globally. These caches display error messages using `toast`, unless the `doNotShowToast` metadata is set to `true`.
* [`app/components/app/query-provider.tsx`](diffhunk://#diff-8895ce3212eab379a183f1cd98fe1858c5b413b64b85b765ef29d8ba3d071037L3-R16): Extended the `@tanstack/react-query` module to include `doNotShowToast` metadata for both queries and mutations, enabling selective suppression of error toasts.

### Code simplification in `RegisterForm`:

* [`app/components/register/register-form.tsx`](diffhunk://#diff-1bf980f7832aea43ad9cf8682b72c64aac732a0fd1c6348f9bb8973602d3ac45L54-L56): Removed the `onError` handler for mutations, as error handling is now centralized in the `MutationCache` of the `QueryProvider`.